### PR TITLE
api/api-handler apiRequest function was fixed

### DIFF
--- a/client/api/api-handler.ts
+++ b/client/api/api-handler.ts
@@ -23,13 +23,13 @@ export const apiRequest = (getToken?: () => Promise<string | null>) => async (
         throw new Error(`Error ${response.status}: ${response.statusText}`)
     }
 
-    //parse:
-    let text
-    try{ text = await response.text() }catch(err){
-        throw new Error('Could not parse response', err as ErrorOptions) //tmp
-    }
-    try{ return JSON.parse(text) }catch(err){
-        throw new Error(`Could not parse response to JSON. ${text}`, err as ErrorOptions) //tmp
+    const contentType = response.headers.get('Content-Type') || '';
+
+    if (contentType.includes('application/json')) {
+        return response.json().catch((err) => {
+            throw new Error(`Failed to parse JSON: ${err.message}`);
+        });
     }
 
+    return response.text();
 }


### PR DESCRIPTION
problem : 
After calling `useServices(1)`, several functions execute and eventually reaching the apiRequest function in api/api-handler. 
In my scenario, the server responded with an HTML file, but the code attempted to parse it as JSON, resulting in an error.

solution : I check the Content-Type of the response. If it's JSON, I parse it; otherwise, I return it as is.